### PR TITLE
Command spells no longer grant magic skill.

### DIFF
--- a/src/Game/NeoServer.Game.Common/Contracts/Spells/ISpell.cs
+++ b/src/Game/NeoServer.Game.Common/Contracts/Spells/ISpell.cs
@@ -28,6 +28,6 @@ namespace NeoServer.Game.Common.Contracts.Spells
     public interface ICommandSpell : ISpell
     {
         public object[] Params { get; set; }
-        new bool IncreaseSkill => false;
+        bool ISpell.IncreaseSkill => false;
     }
 }


### PR DESCRIPTION
`ICommandSpell` now properly overrides `bool IncreaseSkill`. The way it was implemented previously was ignored by C#.